### PR TITLE
fix: potential validation problems

### DIFF
--- a/mosaic_subnet/validator/__init__.py
+++ b/mosaic_subnet/validator/__init__.py
@@ -22,11 +22,11 @@ from mosaic_subnet.validator.model import CLIP
 from mosaic_subnet.base.utils import get_netuid
 from mosaic_subnet.base import SampleInput, BaseValidator
 from mosaic_subnet.validator.dataset import ValidationDataset
-from mosaic_subnet.validator.math import threshold_sigmoid_reward_distribution
+from mosaic_subnet.validator.sigmoid import threshold_sigmoid_reward_distribution
 
 
 class Validator(BaseValidator, Module):
-    def __init__(self, key: Keypair, settings: ValidatorSettings = None) -> None:
+    def __init__(self, key: Keypair, settings: ValidatorSettings | None = None) -> None:
         super().__init__()
         self.settings = settings or ValidatorSettings()
         self.key = key
@@ -80,7 +80,7 @@ class Validator(BaseValidator, Module):
         # Iterate over the items in the score_dict
         for uid, score in adjsuted_to_sigmoid.items():
             # Calculate the normalized weight as an integer
-            weight = int(score / scores * 10)
+            weight = int(score * 1000 / scores)
 
             # Add the weighted score to the new dictionary
             weighted_scores[uid] = weight

--- a/mosaic_subnet/validator/sigmoid.py
+++ b/mosaic_subnet/validator/sigmoid.py
@@ -22,7 +22,7 @@ def threshold_sigmoid_reward_distribution(score_dict: dict[int, float]) -> dict[
     threshold = mean_score * (1 + threshold_percentage)
 
    
-    steepness = 20.0  # steepness for sharper punishment
+    steepness = 5.0  # steepness for sharper punishment
 
     # Set the high and low rewards
     high_reward = 1.0


### PR DESCRIPTION
The output of the sigmoid is a number between 0-1. It is usually on the lower side, < 0.5. When you multiply by 10 and convert to int, it might not be enough, and you might be getting false 0 scores. Also, the steepness of the sigmoid at 20 is a bit too much for aligned consensus, in my opinion.
